### PR TITLE
New model for test tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,26 @@ AdventOfCode.Input.get!(7)
 AdventOfCode.Input.delete!(7, 2019)
 # and the next time you `get!` it will download a fresh one -- use this sparingly!
 ```
+
+
+### Testing and Running your code
+
+You can adjust your test to reflect the sample provided at the challenge description. And run your tests:
+```bash
+mix test --only y2024.d01.p1
+mix test --only y2024.d01
+mix text --only y2024
+```
+
+This syntax is pretty straight forward, the first one will run the test for a particular part, the second will run all the tests for that day, and the third one for the year.
+
+As you progress with the challenge you'll find edge cases, and you can create your own tests for that and even reuse some of those tags.
+
+When you're done with testing you can run your code with the command:
+```bash
+mix y2024.d01.p1
+```
+
+The identification of the task to run your code and the name of the test follows the same structure, so it's easy to move between those.
+
+

--- a/lib/mix/tasks/advent.generate.day.ex
+++ b/lib/mix/tasks/advent.generate.day.ex
@@ -59,10 +59,11 @@ defmodule Mix.Tasks.Advent.Generate.Day do
       test_module_name,
       """
         use ExUnit.Case
-
         import #{day_module_name}
+        @moduletag :"y#{year}.d#{full_day_number}"
+        @moduletag :y#{year}
 
-        @tag :skip
+        @tag :"y#{year}.d#{full_day_number}.p1"
         test "part1" do
           input = nil
           result = part1(input)
@@ -70,7 +71,7 @@ defmodule Mix.Tasks.Advent.Generate.Day do
           assert result
         end
 
-        @tag :skip
+        @tag :"y#{year}.d#{full_day_number}.p2"
         test "part2" do
           input = nil
           result = part2(input)


### PR DESCRIPTION
To simplify defining which test to run, I've implemented this change that will tag the default test structure, and tests can be run with the following commands:

```bash
$ mix test --only y2024
$ mix test --only y2024.d01
$ mix test --only y2024.d01.p1
```

It is easier than editing tests and removing `:skip` tags.

Test tags follows the same structure of the tasks to effectively run your code against your input. So it is easier to change from one to another.
